### PR TITLE
Update Result.php

### DIFF
--- a/src/Dibi/Result.php
+++ b/src/Dibi/Result.php
@@ -160,7 +160,7 @@ class Result implements IDataSource
 	 * Fetches the row at current position, process optional type conversion.
 	 * and moves the internal cursor to the next position
 	 */
-	final public function fetch(): Row|array|null
+	final public function fetch(): mixed
 	{
 		$row = $this->getResultDriver()->fetch(true);
 		if ($row === null) {


### PR DESCRIPTION
Change fetch return type to mixed due the type conversion

If is setup setRowFactory with some else return type it's ends by error.

[TypeError] Dibi\Result::fetch(): Return value must be of type Dibi\Row|array|null, XXX returned